### PR TITLE
Update class-shortcodes-menu.php

### DIFF
--- a/includes/classes/class-shortcodes-menu.php
+++ b/includes/classes/class-shortcodes-menu.php
@@ -70,3 +70,5 @@ class Odin_Shortcodes_Menu {
 		return $locales;
 	}
 }
+
+ new Odin_Shortcodes_Menu;


### PR DESCRIPTION
Estava faltando instanciar a classe; O menu não aparecia para usuário no Editor.